### PR TITLE
fix(invoice): allow future dates up to end of Y+2

### DIFF
--- a/client/src/shema/InvoiceShema.ts
+++ b/client/src/shema/InvoiceShema.ts
@@ -54,7 +54,7 @@ export const invoiceSchema = z.object({
                 ctx.addIssue({ code: 'custom', message: "Format requis: JJ/MM/AAAA" });
                 return;
             }
-            if (!isValidateDate(val)) {
+            if (!isValidateDate(val, { allowedFutur: true })) {
                 ctx.addIssue({ code: 'custom', message: "Date invalide ou dans le futur" });
             }
         }),
@@ -68,7 +68,7 @@ export const invoiceSchema = z.object({
                 ctx.addIssue({ code: 'custom', message: "Format requis: JJ/MM/AAAA" });
                 return;
             }
-            if (!isValidateDate(val)) {
+            if (!isValidateDate(val, { allowedFutur: true })) {
                 ctx.addIssue({ code: 'custom', message: "Date invalide ou dans le futur" });
             }
         }),
@@ -119,7 +119,7 @@ export const invoiceSchema = z.object({
     folio: z.enum(["1 copie", "Orig + 1 copie", "Orig + 2 copies", "Orig + 3 copies"], { error: "Folio invalide" }),
     documents: z.array(z.enum(allowedDocument)).optional().transform(val => val?.filter(Boolean))
 }).refine((data) => {
-    if (!isValidateDate(data.invoice_date) || !isValidateDate(data.invoice_arrival_date)) return true;
+    if (!isValidateDate(data.invoice_date, { allowedFutur: true }) || !isValidateDate(data.invoice_arrival_date, { allowedFutur: true })) return true;
     const invoiceDate = parseDate(data.invoice_date);
     const arrivalDate = parseDate(data.invoice_arrival_date);
     if (!invoiceDate || !arrivalDate) return true;

--- a/client/src/utils/validateDate.js
+++ b/client/src/utils/validateDate.js
@@ -26,7 +26,11 @@ export default function isValidateDate(dateStr, { allowedFutur = false } = {}) {
         date.getMonth() + 1 !== month ||
         date.getFullYear() !== year) return false;
 
-    return allowedFutur ? true : date <= now;
+    if (!allowedFutur) return date <= now;
+
+    const maxYearAllowed = now.getFullYear() + 2;
+    const maxDateAllowed = new Date(maxYearAllowed, 11, 31, 23, 59, 59, 999);
+    return date <= maxDateAllowed;
 }
 
 export function parseDate(dateStr) {

--- a/client/src/utils/validateDate.test.js
+++ b/client/src/utils/validateDate.test.js
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import isValidateDate from './validateDate.js';
+
+describe('isValidateDate', () => {
+  it('accepts past dates by default', () => {
+    expect(isValidateDate('01/01/2000')).toBe(true);
+  });
+
+  it('rejects future dates by default', () => {
+    const nextYear = new Date().getFullYear() + 1;
+    expect(isValidateDate(`01/01/${nextYear}`)).toBe(false);
+  });
+
+  it('accepts future dates up to end of current year + 2 when allowedFutur is enabled', () => {
+    const maxYear = new Date().getFullYear() + 2;
+    expect(isValidateDate(`31/12/${maxYear}`, { allowedFutur: true })).toBe(true);
+  });
+
+  it('rejects future dates beyond end of current year + 2 when allowedFutur is enabled', () => {
+    const tooFarYear = new Date().getFullYear() + 3;
+    expect(isValidateDate(`01/01/${tooFarYear}`, { allowedFutur: true })).toBe(false);
+  });
+});


### PR DESCRIPTION
Align date validation with business rule (current year + 2).

Update Zod schema and add Vitest coverage for boundary cases.

Fixes #1