### PR TITLE
fix: prevent invoice form disabled when quota is null

### DIFF
--- a/client/src/features/invoices/InvoiceForm.jsx
+++ b/client/src/features/invoices/InvoiceForm.jsx
@@ -100,14 +100,14 @@ function InvoiceForm() {
         lastInvoiceNumber={lastInvoiceNumber}
         isLoading={loading}
         fiscalYear={fiscalYear}
-        disabled={Number(remaining) === 0}
+        disabled={remaining !== null && Number(remaining) === 0}
       >
         {warningInfo?.warning === true && (
           <div className="mb-4 p-3 rounded-md bg-yellow-50 text-yellow-800 border border-yellow-200">
             Attention: le seuil annuel approche. Restant: {warningInfo.remaining}
           </div>
         )}
-        {Number(remaining) === 0 && (
+        {remaining !== null && Number(remaining) === 0 && (
           <div className="mb-4 p-3 rounded-md bg-red-50 text-red-800 border border-red-200">
             Le quota de numéros pour l'année fiscale courante est épuisé. Veuillez démarrer une nouvelle année fiscale.
           </div>


### PR DESCRIPTION
## Description

This PR fixes a critical bug where the invoice creation form was incorrectly disabled even when the fiscal year had an available quota.

### The Bug
The issue was caused by the condition `Number(remaining) === 0` in [InvoiceForm.jsx](cci:7://file:///c:/Users/ASUS/invoice-app/client/src/features/invoices/InvoiceForm.jsx:0:0-0:0). 
When the fiscal settings data is being loaded from the API, the `remaining` value is initially `null`. In JavaScript, `Number(null)` evaluates to `0`, which caused the form to be disabled immediately upon loading, treating the loading state as "quota exhausted".

### The Fix
The condition has been updated to explicitly check that `remaining` is not `null` before checking if it equals 0.
```javascript
// Before
disabled={Number(remaining) === 0}

// After
disabled={remaining !== null && Number(remaining) === 0}